### PR TITLE
Added os.exit

### DIFF
--- a/core/os.d.ts
+++ b/core/os.d.ts
@@ -10,13 +10,10 @@ declare namespace os {
   function clock(): number;
 
   /**
-   * Calls the ISO C function exit to terminate the host program. If code is true,
-   * the returned status is EXIT_SUCCESS; if code is false, the returned status is
-   * EXIT_FAILURE; if code is a number, the returned status is this number. The
-   * default value for code is true.
+   * Calls the ISO C function exit to terminate the host program. If code is true, the returned status is EXIT_SUCCESS; if code is false, the returned status is EXIT_FAILURE; if code is a number, the returned status is this number.
+   * The default value for code is true.
    *
-   * If the optional second argument close is true, closes the Lua state before
-   * exiting.
+   * If the optional second argument close is true, closes the Lua state before exiting.
    */
   export function exit(code?: boolean | number, close?: boolean): never;
 

--- a/core/os.d.ts
+++ b/core/os.d.ts
@@ -10,6 +10,17 @@ declare namespace os {
   function clock(): number;
 
   /**
+   * Calls the ISO C function exit to terminate the host program. If code is true,
+   * the returned status is EXIT_SUCCESS; if code is false, the returned status is
+   * EXIT_FAILURE; if code is a number, the returned status is this number. The
+   * default value for code is true.
+   *
+   * If the optional second argument close is true, closes the Lua state before
+   * exiting.
+   */
+  export function exit(code?: boolean | number, close?: boolean): never;
+
+  /**
    * Returns a string or a table containing date and time, formatted according to the given string format.
    *
    * If the time argument is present, this is the time to be formatted (see the os.time function for a description of this value). Otherwise, date formats the current time.


### PR DESCRIPTION
`os.exit` exists in Lua 5.1, 5.2, 5.3, 5.4 and JIT. Thought I'd add it in